### PR TITLE
[draft] xsd:documentation elementen 

### DIFF
--- a/ORI.xsd
+++ b/ORI.xsd
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns="https://vng.nl/projecten/open-raadsinformatie" targetNamespace="https://vng.nl/projecten/open-raadsinformatie" elementFormDefault="qualified" version="v0.0.1">
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://vng.nl/projecten/open-raadsinformatie" targetNamespace="https://vng.nl/projecten/open-raadsinformatie" elementFormDefault="qualified" version="v0.0.1">
 	<xsd:element name="ORI" type="ORI"/>
 	<xsd:complexType name="ORI">
 		<xsd:sequence>
 			<xsd:element name="vergadering" type="vergadering" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Een `vergadering` is een bijeenkomst van meerdere mensen die met elkaar spreken en/of afspraken maken over onderwerpen die op de agenda staan.</xsd:documentation>
+			  <xsd:annotation>
+				<!-- Misschien handig om de relaties te documenteren? voor informatieobject is dit al gedaan -->
+				<xsd:documentation>Een bijeenkomst waarin een of meer agendapunten worden besproken.</xsd:documentation>
+				
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="agendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>Een onderdeel van de agenda dat als één geheel wordt behandeld. Een `agendapunt` kan weer onderverdeeld zijn in subagendapunten.</xsd:documentation>
+					<xsd:documentation>Een onderdeel van de agenda dat als één geheel wordt behandeld. Een agendapunt kan weer onderverdeeld zijn in subagendapunten.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="stemming" type="stemming" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>Een moment waarop een keuze gemaakt moet worden over een bepaald `agendapunt` of `vergaderstuk`, waarbij alle uitgebrachte stemmen geteld worden. Alleen aanwezige raadsleden (gemeente) of statenleden (provincie) kunnen een stem uitbrengen.</xsd:documentation>
+					<xsd:documentation>Een moment waarop aanwezige deelnemers een stemming uitbrengen over een bepaald agendapunt of vergaderstuk.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="besluit" type="besluit" minOccurs="0" maxOccurs="unbounded">
@@ -30,7 +32,7 @@
 			</xsd:element>
 			<xsd:element name="organisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>Het deel van een functioneel afgebakend onderdeel binnen de organisatie die verantwoordelijk is voor de behandeling van zaken.</xsd:documentation>
+					<xsd:documentation>Een functioneel afgebakend onderdeel binnen een organisatie die verantwoordelijk is voor het indienen van een informatieobject.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="zaak" type="zaak" minOccurs="0" maxOccurs="unbounded">
@@ -130,7 +132,7 @@
 		<xsd:sequence>
 			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+					<xsd:documentation>Uniek identificatie kenmerk van de vergadering.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
@@ -140,7 +142,7 @@
 			</xsd:element>
 			<xsd:element name="vergaderToelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>De toelichting of nadere omschrijving van de vergadering.</xsd:documentation>
+					<xsd:documentation>Toelichting of nadere omschrijving van de vergadering.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="georganiseerdDoorGremium" type="gremium" minOccurs="0" maxOccurs="1">
@@ -150,15 +152,16 @@
 			</xsd:element>
 			<xsd:element name="vergaderingstype" type="vergaderingstype" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>De type-aanduiding van de vergadering. 
+				  <xsd:documentation>
+					De type-aanduiding van de **vergadering**.
 
                     Mogelijke type:
-                      * raadsvergadering 
-                      * commissievergadering
-                      * presidium
-                      * statenvergadering
-                      * algemene_bestuursvergadering
-                    </xsd:documentation>
+					  - `raadsvergadering`
+					  - `commissievergadering`
+					  - presidium
+					  - statenvergadering
+					  - algemene bestuursvergadering
+					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="locatie" type="xsd:string" minOccurs="0" maxOccurs="1">
@@ -173,12 +176,12 @@
 			</xsd:element>
 			<xsd:element name="geplandeVergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>De geplande datum van de `vergadering`.</xsd:documentation>
+					<xsd:documentation>De geplande datum van de vergadering.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="vergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>De datum van de `vergadering`.</xsd:documentation>
+					<xsd:documentation>De datum van de vergadering.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="geplandeAanvangVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
@@ -203,12 +206,13 @@
 			</xsd:element>
 			<xsd:element name="publicatiedatum" type="xsd:date" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>De datum waarop de vergadering voor het laatst gepubliceerd is. Het kan zijn dat er wijzigingen hebben plaatsgevonden en dat de vergadering opnieuw is gepubliceerd. Dit veld bevat de meest recente publicatiedatum.</xsd:documentation>
+					<xsd:documentation>Meest recente publicatiedatum van een vergadering.
+					De datum waarop de vergadering voor het laatst gepubliceerd is. Het kan zijn dat er wijzigingen hebben plaatsgevonden en dat de vergadering opnieuw is gepubliceerd. Dit veld bevat de meest recente publicatiedatum.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
+					<xsd:documentation>Geeft aan welke bestuurslaag de verantwoordelijk die de vergadering geiniteerd heeft. TODO</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="isVastgelegdMiddels" type="mediabron" minOccurs="0" maxOccurs="unbounded">
@@ -498,7 +502,7 @@
 * `burgerlid` - Burgerlid
 * `griffier` - Griffier
 * `gemeentesecretaris` - Gemeentesecretaris
-* `ambtenaar_of_medewerker` - Ambtenaar of medewerker van gemeente of provincie
+* `ambtenaar of medewerker` - Ambtenaar of medewerker van gemeente of provincie
 * `adviseur_of_deskundige` - Adviseur of deskundige
 * `overig` - Overig
 * `commissaris_van_de_koning` - Commissaris van de koning Commissaris van de Koning of Koningin (hoort bij de provincie)
@@ -1005,7 +1009,7 @@
 		<xsd:sequence>
 			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+					<xsd:documentation>Uniek identificatie kenmerk van de vergadering.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">

--- a/ORI.xsd
+++ b/ORI.xsd
@@ -10,7 +10,7 @@
 			</xsd:element>
 			<xsd:element name="agendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>Een onderdeel van de agenda dat als één geheel wordt behandeld. Een `agendapunt` kan weer onderverdeeld zijn naar subagendapunten.</xsd:documentation>
+					<xsd:documentation>Een onderdeel van de agenda dat als één geheel wordt behandeld. Een `agendapunt` kan weer onderverdeeld zijn in subagendapunten.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="stemming" type="stemming" minOccurs="0" maxOccurs="unbounded">
@@ -20,7 +20,7 @@
 			</xsd:element>
 			<xsd:element name="besluit" type="besluit" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>Een na beraadslaging vastgestelde beslissing Een na overweging of beraadslaging vastgestelde beslissing voor een individueel of concreet geval.</xsd:documentation>
+					<xsd:documentation>Een na beraadslaging vastgestelde beslissing.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="indiener" type="indiener" minOccurs="0" maxOccurs="unbounded">
@@ -30,17 +30,28 @@
 			</xsd:element>
 			<xsd:element name="organisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>Het deel van een functioneel afgebakend onderdeel binnen de organisatie dat haar activiteiten uitvoert binnen een `vestiging` `van` `zaakbehandelende` `organisatie` en die verantwoordelijk is voor de behandeling van zaken.</xsd:documentation>
+					<xsd:documentation>Het deel van een functioneel afgebakend onderdeel binnen de organisatie die verantwoordelijk is voor de behandeling van zaken.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="zaak" type="zaak" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>Identificatie van de zaak.</xsd:documentation>
+					<xsd:documentation>TODO.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="informatieobject" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
+					<xsd:documentation>
+					<![CDATA[
+					Een op zichzelf staand geheel van gegevens met een eigen identiteit, inclusief
+					bijbehorende metadata ontvangen of gecreëerd door een natuurlijke en/of
+					rechtspersoon bij de uitvoering van diens taken.
+
+					Een informatieobject is altijd gekoppeld aan minimaal een van de volgende objecten:
+					  * Vergadering
+					  * Agendapunt
+					  * Stemming
+					]]>
+					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="enkelvoudigInformatieobject" type="enkelvoudigInformatieobject" minOccurs="0" maxOccurs="unbounded">
@@ -134,17 +145,20 @@
 			</xsd:element>
 			<xsd:element name="georganiseerdDoorGremium" type="gremium" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>De vergadering is georganiseerd door een gremium.</xsd:documentation>
+					<xsd:documentation>Het gremium dat de vergadering georganiseerd heeft.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="vergaderingstype" type="vergaderingstype" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>De mogelijke typen van een `vergadering` behorende bij de gemeenteraad* `raadsvergadering` - Raadsvergadering is van toepassing bij gemeenten
-* `commissievergadering` - Commissievergadering is van toepassing bij gemeenten
-* `presidium` - Presidium
-* `statenvergadering` - Statenvergadering is van toepassing bij provincies
-* `algemene_bestuursvergadering` - Algemene bestuursvergadering is van toepassing bij waterschappen
-.</xsd:documentation>
+					<xsd:documentation>De type-aanduiding van de vergadering. 
+
+                    Mogelijke type:
+                      * raadsvergadering 
+                      * commissievergadering
+                      * presidium
+                      * statenvergadering
+                      * algemene_bestuursvergadering
+                    </xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="locatie" type="xsd:string" minOccurs="0" maxOccurs="1">
@@ -189,7 +203,7 @@
 			</xsd:element>
 			<xsd:element name="publicatiedatum" type="xsd:date" minOccurs="0" maxOccurs="1">
 				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
+					<xsd:documentation>De datum waarop de vergadering voor het laatst gepubliceerd is. Het kan zijn dat er wijzigingen hebben plaatsgevonden en dat de vergadering opnieuw is gepubliceerd. Dit veld bevat de meest recente publicatiedatum.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">

--- a/ORI.xsd
+++ b/ORI.xsd
@@ -3,220 +3,853 @@
 	<xsd:element name="ORI" type="ORI"/>
 	<xsd:complexType name="ORI">
 		<xsd:sequence>
-			<xsd:element name="vergadering" type="vergadering" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="agendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="stemming" type="stemming" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="besluit" type="besluit" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="indiener" type="indiener" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="organisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="zaak" type="zaak" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="informatieobject" type="informatieobject" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="enkelvoudigInformatieobject" type="enkelvoudigInformatieobject" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="motie" type="motie" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="amendement" type="amendement" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="voorstel" type="voorstel" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="ingekomenStuk" type="ingekomenStuk" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="vraag" type="vraag" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="antwoord" type="antwoord" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="toezegging" type="toezegging" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="mededeling" type="mededeling" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="natuurlijkPersoon" type="natuurlijkPersoon" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="aanwezigeDeelnemer" type="aanwezigeDeelnemer" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="dagelijksBestuur" type="dagelijksBestuur" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="fractie" type="fractie" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="mediabron" type="mediabron" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="vergadering" type="vergadering" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Een `vergadering` is een bijeenkomst van meerdere mensen die met elkaar spreken en/of afspraken maken over onderwerpen die op de agenda staan.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="agendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Een onderdeel van de agenda dat als één geheel wordt behandeld. Een `agendapunt` kan weer onderverdeeld zijn naar subagendapunten.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="stemming" type="stemming" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Een moment waarop een keuze gemaakt moet worden over een bepaald `agendapunt` of `vergaderstuk`, waarbij alle uitgebrachte stemmen geteld worden. Alleen aanwezige raadsleden (gemeente) of statenleden (provincie) kunnen een stem uitbrengen.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="besluit" type="besluit" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Een na beraadslaging vastgestelde beslissing Een na overweging of beraadslaging vastgestelde beslissing voor een individueel of concreet geval.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="indiener" type="indiener" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>De indiener, zijnde een natuurlijk persoon of een organisatorische eenheid, van een informatieobject.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="organisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Het deel van een functioneel afgebakend onderdeel binnen de organisatie dat haar activiteiten uitvoert binnen een `vestiging` `van` `zaakbehandelende` `organisatie` en die verantwoordelijk is voor de behandeling van zaken.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="zaak" type="zaak" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Identificatie van de zaak.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="informatieobject" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="enkelvoudigInformatieobject" type="enkelvoudigInformatieobject" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="motie" type="motie" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="amendement" type="amendement" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="voorstel" type="voorstel" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ingekomenStuk" type="ingekomenStuk" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vraag" type="vraag" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="antwoord" type="antwoord" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="toezegging" type="toezegging" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Bij een `besluit` kan een additionele toezegging gedaan worden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="mededeling" type="mededeling" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="natuurlijkPersoon" type="natuurlijkPersoon" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="aanwezigeDeelnemer" type="aanwezigeDeelnemer" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>De NATUURLIJKe `persoon` die deelneemt aan een `vergadering`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="dagelijksBestuur" type="dagelijksBestuur" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Het dagelijkse bestuur van de gemeente (college) of provincie (gedeputeerde staten) bereidt het beleid voor en voert dit beleid uit.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="fractie" type="fractie" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Deel van een gekozen volksvertegenwoordiging.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="mediabron" type="mediabron" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Verwijzing naar de mediabron waarin het `spreekfragment` is vastgelegd.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="vergadering">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="vergaderToelichting" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="georganiseerdDoorGremium" type="gremium" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="vergaderingstype" type="vergaderingstype" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="locatie" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="status" type="vergaderingStatus" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="geplandeVergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="vergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="geplandeAanvangVergadering" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="geplandeEindeVergadering" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="aanvangVergadering" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="eindeVergadering" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="publicatiedatum" type="xsd:date" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="isVastgelegdMiddels" type="mediabron" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="isGenotuleerdIn" type="informatieobject" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="heeftAlsBijlage" type="informatieobject" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="heeftAlsDeelvergadering" type="vergadering" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van de vergadering.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vergaderToelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De toelichting of nadere omschrijving van de vergadering.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="georganiseerdDoorGremium" type="gremium" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De vergadering is georganiseerd door een gremium.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vergaderingstype" type="vergaderingstype" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De mogelijke typen van een `vergadering` behorende bij de gemeenteraad* `raadsvergadering` - Raadsvergadering is van toepassing bij gemeenten
+* `commissievergadering` - Commissievergadering is van toepassing bij gemeenten
+* `presidium` - Presidium
+* `statenvergadering` - Statenvergadering is van toepassing bij provincies
+* `algemene_bestuursvergadering` - Algemene bestuursvergadering is van toepassing bij waterschappen
+.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="locatie" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Omschrijving van de locatie waar de vergadering wordt gehouden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="status" type="vergaderingStatus" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="geplandeVergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De geplande datum van de `vergadering`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum van de `vergadering`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="geplandeAanvangVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De geplande datum en tijdstip waarop de vergadering start.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="geplandeEindeVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De geplande datum en tijdstip waarop de vergadering eindigt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="aanvangVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum en tijdstip waarop de vergadering is gestart Komt zeker voor als Einde vergadering ook is ingevuld.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="eindeVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum en tijdstip waarop de vergadering is geëindigd.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="publicatiedatum" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="isVastgelegdMiddels" type="mediabron" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="isGenotuleerdIn" type="informatieobject" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="heeftAlsBijlage" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="heeftAlsDeelvergadering" type="vergadering" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="agendapunt">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="agendapuntOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="geplandAgendapuntVolgnummer" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="agendapuntVolgnummer" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="geplandeEindtijd" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="geplandeStarttijd" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="starttijd" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="eindtijd" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="agendapuntKenmerk" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="agendapuntTitel" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="indicatieHamerstuk" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="indicatorBehandeld" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="indicatorBesloten" type="xsd:boolean" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="wordtBehandeldTijdens" type="vergadering" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="heeftAlsSubagendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="heeftBehandelendAmbtenaar" type="natuurlijkPersoon" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="heeftAlsBijlage" type="informatieobject" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="agendapuntOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De omschrijving van het agendapunt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="geplandAgendapuntVolgnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Dit is het geplande volgnummer van het `agendapunt` van een vergadering.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="agendapuntVolgnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Dit is het volgnummer van het `agendapunt` tijdens de vergadering. Dit is de letterlijke volgorde en zegt niets over hoe dit volgnummer getoond wordt. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="geplandeEindtijd" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De geplande datum en tijdstip waarop de behandeling van de agendapunt eindigt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="geplandeStarttijd" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De geplande datum en tijdstip waarop de behandeling van de agendapunt start.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="starttijd" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum en tijdstip waarop de behandeling van de agendapunt is gestart.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="eindtijd" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum en tijdstip waarop de behandeling van de agendapunt is geëindigd. Moet voorkomen als Starttijd voorkomt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="agendapuntKenmerk" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De weergave van het Agendapuntvolgnummer op de agenda. Dit is de letterlijke volgorde van een Agendapunt wordt bij gehouden d.m.v. attribuut 'Agendapuntvolgnummer'. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="agendapuntTitel" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De titel of onderwerp van het agendapunt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="indicatieHamerstuk" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="indicatorBehandeld" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Indicator geeft aan of het `agendapunt` is behandeld tijdens de `vergadering`. Is eventueel af te leiden als Starttijd en/of Eindtijd zijn ingevuld.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="indicatorBesloten" type="xsd:boolean" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Indicator of een `agendapunt` besloten wordt behandeld.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="wordtBehandeldTijdens" type="vergadering" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="heeftAlsSubagendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="heeftBehandelendAmbtenaar" type="natuurlijkPersoon" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="heeftAlsBijlage" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="spreekfragment">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="aanvangSpreekfragment" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="eindeSpreekfragment" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="taal" type="xsd:language" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="tekstSpreekfragment" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="titelSpreekfragment" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="positieNotulen" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="audioTijdsaanduidingAanvang" type="xsd:integer" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="audioTijdsaanduidingEinde" type="xsd:integer" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="videoTijdsaanduidingAanvang" type="xsd:integer" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="videoTijdsaanduidingEinde" type="xsd:integer" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="isVastgelegdIn" type="mediabron" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="spreektTijdens" type="agendapunt" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="aanvangSpreekfragment" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Het tijdstip en de datum van aanvang van het `spreekfragment`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="eindeSpreekfragment" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Het tijdstip en de datum van einde van het `spreekfragment`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="taal" type="xsd:language" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De taal van het informatieobject. Bij voorkeur aaangeduid volgens `iso` 639-2/`b`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="tekstSpreekfragment" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De uitgeschreven weergave van het `spreekfragment`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="titelSpreekfragment" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De titel die kenmerkend is voor het `spreekfragment` of deel van de discussie.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="positieNotulen" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De positie van het `spreekfragment` binnen de notulen.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="audioTijdsaanduidingAanvang" type="xsd:integer" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De tijdsaanduiding van de aanvang van het `spreekfragment` in de audio opname in seconden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="audioTijdsaanduidingEinde" type="xsd:integer" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De tijdsaanduiding van het einde van het `spreekfragment` in de audio opname in seconden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="videoTijdsaanduidingAanvang" type="xsd:integer" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De tijdsaanduiding van de aanvang van het `spreekfragment` in de video opname in seconden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="videoTijdsaanduidingEinde" type="xsd:integer" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De tijdsaanduiding van het einde van het `spreekfragment` in de video opname in seconden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="isVastgelegdIn" type="mediabron" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="spreektTijdens" type="agendapunt" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="stemming">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="stemmingstype" type="stemmingstype" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="resultaatMondelingeStemming" type="stemmingResultaat" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="resultaatStemmingOverPersonen" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="stemmingOverPersonen" type="stemmingOverPersonen" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="heeftBetrekkingOpAgendapunt" type="agendapunt" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="heeftBetrekkingOpBesluitvormingsstuk" type="besluitvormingsstuk" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="leidtTotBesluit" type="besluit" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="stemmingstype" type="stemmingstype" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+				  <xsd:documentation>
+                  Duiding van het type van een `stemming`
+
+                  * `hoofdelijk` - Hoofdelijk
+                  * `regulier` - Regulier
+                  * `schriftelijk` - Schriftelijk
+                  </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="resultaatMondelingeStemming" type="stemmingResultaat" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="resultaatStemmingOverPersonen" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Het resultaat van de stemming over één of meerdere personen.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="stemmingOverPersonen" type="stemmingOverPersonen" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De individuele uitgebrachte STEMmen over personen zijn geheim. Alleen het aantal uitgebrachte stemmen per kandidaat is bekend.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="heeftBetrekkingOpAgendapunt" type="agendapunt" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="heeftBetrekkingOpBesluitvormingsstuk" type="besluitvormingsstuk" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="leidtTotBesluit" type="besluit" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="mediabron">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="locatieWebVTTBestand" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="mimetype" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="mediabronType" type="mediabronType" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="URL" type="xsd:anyURI" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="locatieWebVTTBestand" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De locatie waar het Webvttbestand is opgeslagen.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="mimetype" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Het type bestand dat is opgeslagen.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="mediabronType" type="mediabronType" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>* `video` - Video technische vragen over een agendapunt
+* `audio` - Audio
+* `transcriptie` - Transcriptie
+.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="URL" type="xsd:anyURI" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="natuurlijkPersoon">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="geslachtsaanduiding" type="geslacht" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="functie" type="functie" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="naamNatuurlijkPersoon" type="naamNatuurlijkPersoon" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="nevenfunctieNatuurlijkPersoon" type="nevenfunctieNatuurlijkPersoon" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="isLidVanFractie" type="fractielidmaatschap" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="isLidVanDagelijksBestuur" type="dagelijksBestuurLidmaatschap" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="geslachtsaanduiding" type="geslacht" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="functie" type="functie" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>* `burgemeester` - Burgemeester van de gemeente
+* `wethouder` - Wethouder van de gemeente
+* `raadslid` - Raadslid van de gemeente
+* `burgerlid` - Burgerlid
+* `griffier` - Griffier
+* `gemeentesecretaris` - Gemeentesecretaris
+* `ambtenaar_of_medewerker` - Ambtenaar of medewerker van gemeente of provincie
+* `adviseur_of_deskundige` - Adviseur of deskundige
+* `overig` - Overig
+* `commissaris_van_de_koning` - Commissaris van de koning Commissaris van de Koning of Koningin (hoort bij de provincie)
+* `gedeputeerde` - Gedeputeerde van de provincie
+* `statenlid` - Statenlid van de provincie
+* `provinciesecretaris` - Provinciesecretaris
+* `dijkgraaf` - Dijkgraaf Waterschappen
+* `dagelijks_bestuurslid` - Dagelijks bestuurslid Waterschappen
+* `algemeen_bestuurslid` - Algemeen bestuurslid Waterschappen
+* `secretarisdirecteur` - Secretarisdirecteur Waterschappen
+.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="naamNatuurlijkPersoon" type="naamNatuurlijkPersoon" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van een natuurlijk persoon. Wanneer de naam bij het invullen niet opgesplitst is in voornamen, tussenvoegsel en achternaam kan de naam ook in één keer worden geregistreerd in het veld volledigeNaam.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="nevenfunctieNatuurlijkPersoon" type="nevenfunctieNatuurlijkPersoon" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="isLidVanFractie" type="fractielidmaatschap" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="isLidVanDagelijksBestuur" type="dagelijksBestuurLidmaatschap" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="naamNatuurlijkPersoon">
 		<xsd:sequence>
-			<xsd:element name="achternaam" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="tussenvoegsel" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="voorletters" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="voornamen" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="volledigeNaam" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="achternaam" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De achternaam van een `natuurlijk persoon`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="tussenvoegsel" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De tussenvoegsel van een `natuurlijk persoon`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="voorletters" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De voorletters van een `natuurlijk persoon`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="voornamen" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De voornamen van een `natuurlijk persoon`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="volledigeNaam" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De volledige naam van een `natuurlijk persoon`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="nevenfunctieNatuurlijkPersoon">
 		<xsd:sequence>
-			<xsd:element name="omschrijvingNevenfunctie" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="naamOrganisatieNevenfunctie" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="aantalUrenperMaand" type="xsd:integer" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="indicatorBezoldigd" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="indicatorNevenfunctieVanwegeLidmaatschap" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="datumMelding" type="xsd:date" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="datumAanvangNevenfunctie" type="xsd:date" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="datumEindeNevenfunctie" type="xsd:date" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="omschrijvingNevenfunctie" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="naamOrganisatieNevenfunctie" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van de organisatie van de nevenfunctie.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="aantalUrenperMaand" type="xsd:integer" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Het aantal uren dat per maand besteed wordt aan de nevenfunctie.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="indicatorBezoldigd" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Indicator of de nevenfunctie uitgevoerd wordt tegen betaling.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="indicatorNevenfunctieVanwegeLidmaatschap" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="datumMelding" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum waarop de nevenfunctie gemeld is bij de griffier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="datumAanvangNevenfunctie" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum van aanvang van de nevenfunctie.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="datumEindeNevenfunctie" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum van het einde van de nevenfunctie.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="organisatorischeEenheid">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="e-mailadres" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="faxnummer" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="naamVerkort" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="omschrijving" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="telefoonnummer" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="toelichting" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="e-mailadres" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Elektronisch postadres waaronder de organisatorische eenheid in de regel bereikbaar is.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="faxnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Faxnummer waaronder de organisatorische eenheid in de regel bereikbaar is.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De feitelijke naam van de organisatorische eenheid.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="naamVerkort" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Een verkorte naam voor de organisatorische eenheid.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="omschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Een omschrijving van de organisatorische eenheid.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="telefoonnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Telefoonnummer waaronder de organisatorische eenheid in de regel bereikbaar is.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="toelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Toelichting bij de organisatorische eenheid.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="stemmingOverPersonen">
 		<xsd:sequence>
-			<xsd:element name="naamKandidaat" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="aantalUitgebrachteStemmen" type="xsd:integer" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="naamKandidaat" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van de kandidaat over wie gestemd is.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="aantalUitgebrachteStemmen" type="xsd:integer" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Het aantal uitgebracht stemmen behorend bij een kandidaat.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="aanwezigeDeelnemer">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="rolNaam" type="rolNaam" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="organisatie" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="deelnemerspositie" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="aanvangAanwezigheid" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="eindeAanwezigheid" type="xsd:time" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="neemtDeelAanVergadering" type="vergadering" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="isNatuurlijkPersoon" type="natuurlijkPersoon" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="neemtDeelAanStemming" type="stem" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="spreektTijdens" type="spreekfragment" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="rolNaam" type="rolNaam" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Duiding van de rollen van een natuurlijke persoon tijdens een vergadering* `voorzitter` - Voorzitter de voorzitter zit de vergadering voor
+* `vice_voorzitter` - Vice voorzitter de vice-voorzitter van de vergadering
+* `raadslid` - Raadslid Een raadslid is een gekozen volksvertegenwoordiger binnen een gemeente. Alle raadsleden van één gemeente vormen samen de gemeenteraad van de betreffende gemeente.
+* `inspreker` - Inspreker Een inspreker is een belanghebbende of betrokkene die wil inspreken bij een agendapunt
+* `overig` - Overig
+* `portefeuillehouder` - Portefeuillehouder de houder van een bepaalde portefeuille.
+* `statenlid` - Statenlid Een statenlid is een gekozen volksvertegenwoordiger binnen een provincie. Alle statenleden van één provincie vormen samen de Provinciale Staten van de betreffende provincie.
+* `dagelijks_bestuurslid` - Dagelijks bestuurslid Waterschappen
+* `algemeen_bestuurslid` - Algemeen bestuurslid Waterschappen
+* `griffier` - Griffier van de vergadering
+.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="organisatie" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van de organisatie die wordt vertegenwoordigd door de aanwezige deelnemer.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="deelnemerspositie" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De plek waar een deelnemer in de zaal zit. Dit kan bijvoorbeeld een stoel of een console zijn. Dit kan o.a. van belang zijn voor de audio/video-verslaggeving.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="aanvangAanwezigheid" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De aanvang van de aanwezigheid.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="eindeAanwezigheid" type="xsd:time" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De einde van de aanwezigheid.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="neemtDeelAanVergadering" type="vergadering" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="isNatuurlijkPersoon" type="natuurlijkPersoon" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="neemtDeelAanStemming" type="stem" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="spreektTijdens" type="spreekfragment" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="dagelijksBestuurLidmaatschap">
 		<xsd:all>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="datumBeginDagelijkseBestuurLidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="datumEindeDagelijkseBestuurLidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="dagelijksBestuur" type="dagelijksBestuur" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="datumBeginDagelijkseBestuurLidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="datumEindeDagelijkseBestuurLidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="dagelijksBestuur" type="dagelijksBestuur" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Verwijzing naar het dagelijks bestuur.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:all>
 	</xsd:complexType>
 	<xsd:complexType name="dagelijksBestuur">
 		<xsd:all>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="dagelijksBestuursnaam" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="dagelijksBestuurstype" type="dagelijksBestuurstype" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>`id` van de resource waarnaar verwezen wordt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="dagelijksBestuursnaam" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Naam van het dagelijks bestuur.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="dagelijksBestuurstype" type="dagelijksBestuurstype" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:all>
 	</xsd:complexType>
 	<xsd:complexType name="zaak">
 		<xsd:sequence>
-			<xsd:element name="zaakID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="zaakregistratie" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="omschrijving" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="zaakID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="zaakregistratie" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Identificatie van de registratie waar de zaak is vastgelegd.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="omschrijving" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Omschrijving van de zaak.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="informatieobject">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="titel" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="bronorganisatie" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="versie" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="auteur" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="creatiedatum" type="xsd:date" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="link" type="xsd:anyURI" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="vertrouwelijkheidsaanduiding" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="zaken" type="zaak" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="titel" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De titel van het informatieobject.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="bronorganisatie" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Bronorganisatie. De in het `nhr` voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="versie" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Versie. Alle alfanumerieke tekens m.u.v. diacrieten.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="auteur" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de `zaak` gerelateerd is, dan wel, indien de auteur niet in een rol aan de `zaak` gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="creatiedatum" type="xsd:date" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Creatiedatum. Alle geldige datums gelegen op of voor de huidige datum en tijd.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="link" type="xsd:anyURI" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De `url` waarmee de inhoud van het informatieobject op te vragen is.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vertrouwelijkheidsaanduiding" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Aanduiding van de vertrouwelijkheid.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="zaken" type="zaak" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Zaken die gerelateerd zijn aan dit informatieobject.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="enkelvoudigInformatieobject">
 		<xsd:complexContent>
 			<xsd:extension base="informatieobject">
 				<xsd:sequence>
-					<xsd:element name="taal" type="xsd:language" minOccurs="0" maxOccurs="1"/>
-					<xsd:element name="inhoud" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="taal" type="xsd:language" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>De taal van het informatieobject. Bij voorkeur aaangeduid volgens `iso` 639-2/`b`.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="inhoud" type="xsd:string" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>Inhoud van het document De content (data) van het enkelvoudig informatieobject in het formaat zoals gespecificeerd met de attribuutsoort 'Formaat'.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -225,7 +858,17 @@
 		<xsd:complexContent>
 			<xsd:extension base="besluitvormingsstuk">
 				<xsd:sequence>
-					<xsd:element name="motieType" type="motieType" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="motieType" type="motieType" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>Duiding van het type van een `motie`* `voorstel` - Voorstel voorstellen van het college van `b`&amp;`w` (gemeente) of van de gedeputueerde staten (provincie) en initiatiefvoorstellen van raadsleden (gemeente) of statenleden (provincie)
+* `afkeuring` - Afkeuring
+* `treurnis` - Treurnis
+* `wantrouwen` - Wantrouwen
+* `vreemd` - Vreemd
+* `overig` - Overig Dit is de standaardwaarde
+.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -234,7 +877,11 @@
 		<xsd:complexContent>
 			<xsd:extension base="enkelvoudigInformatieobject">
 				<xsd:sequence>
-					<xsd:element name="toezeggingsOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="toezeggingsOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>TODO</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -243,8 +890,16 @@
 		<xsd:complexContent>
 			<xsd:extension base="enkelvoudigInformatieobject">
 				<xsd:sequence>
-					<xsd:element name="antwoordOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-					<xsd:element name="behorendBijVraag" type="vraag" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="antwoordOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>TODO</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="behorendBijVraag" type="vraag" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>TODO</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -253,8 +908,16 @@
 		<xsd:complexContent>
 			<xsd:extension base="besluitvormingsstuk">
 				<xsd:sequence>
-					<xsd:element name="portefeuillehouder" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-					<xsd:element name="isIngediendDoor" type="dagelijksBestuur" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="portefeuillehouder" type="xsd:string" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>De naam van de portefeuillehouder van het `voorstel`.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="isIngediendDoor" type="dagelijksBestuur" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>TODO</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -263,7 +926,11 @@
 		<xsd:complexContent>
 			<xsd:extension base="enkelvoudigInformatieobject">
 				<xsd:sequence>
-					<xsd:element name="mededelingOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="mededelingOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>TODO</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -277,107 +944,265 @@
 		<xsd:complexContent>
 			<xsd:extension base="besluitvormingsstuk">
 				<xsd:sequence>
-					<xsd:element name="toelichting" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-					<xsd:element name="hoortBijVoorstel" type="voorstel" minOccurs="0" maxOccurs="1"/>
-					<xsd:element name="subamendementVan" type="amendement" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="toelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>De toelichting op het `amendement`.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="hoortBijVoorstel" type="voorstel" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>TODO</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="subamendementVan" type="amendement" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>TODO</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="besluit">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="besluitToelichting" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="toezegging" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="besluitResultaat" type="besluitResultaat" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="besluitToelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Toelichting bij het besluit.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="toezegging" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Bij een `besluit` kan een additionele toezegging gedaan worden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="besluitResultaat" type="besluitResultaat" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Het resultaat van het `besluit`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="indiener">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="adresBinnenland" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="heeftIngediend" type="informatieobject" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="isNatuurlijkPersoon" type="natuurlijkPersoon" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="isOrganisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De benaming van de indiener.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="adresBinnenland" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De aanduiding van het adres van de indiener.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="heeftIngediend" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="isNatuurlijkPersoon" type="natuurlijkPersoon" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="isOrganisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="besluitvormingsstuk" abstract="true">
 		<xsd:complexContent>
 			<xsd:extension base="enkelvoudigInformatieobject">
 				<xsd:sequence>
-					<xsd:element name="omschrijving" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-					<xsd:element name="datumIngediend" type="xsd:date" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="omschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>TODO</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="datumIngediend" type="xsd:date" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>De datum waarop het `besluitvormingsstuk` is ingediend.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="fractie">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="fractienaam" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="fractieNeemtDeelAanStemming" type="stemresultaatPerFractie" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="fractienaam" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van de fractie.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="fractieNeemtDeelAanStemming" type="stemresultaatPerFractie" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="stemresultaatPerFractie">
 		<xsd:all>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="fractieStemresultaat" type="fractieStemresultaat" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="gegevenOpStemming" type="stemming" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="fractieStemresultaat" type="fractieStemresultaat" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>* `aangenomen` - Aangenomen de gehele aanwezige fractie heeft voor gestemd
+* `verworpen` - Verworpen de gehele aanwezige fractie heeft tegen gestemd
+* `verdeeld` - Verdeeld de stemming in de fractie was verdeeld: een deel was voor en een deel was tegen
+.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gegevenOpStemming" type="stemming" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:all>
 	</xsd:complexType>
 	<xsd:complexType name="fractielidmaatschap">
 		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="datumBeginFractielidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="datumEindeFractielidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="indicatieVoorzitter" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="fractie" type="fractie" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="datumBeginFractielidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum en tijdstip waarop het fractie lidmaatschap begon.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="datumEindeFractielidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum en tijdstip waarop het fractie lidmaatschap geëindigd is.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="indicatieVoorzitter" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Indicatie of iemand de voorzitter is van de `fractie`.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="fractie" type="fractie" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Verwijzing naar de fractie.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="vraag">
 		<xsd:complexContent>
 			<xsd:extension base="enkelvoudigInformatieobject">
 				<xsd:sequence>
-					<xsd:element name="vraagOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-					<xsd:element name="vraagType" type="vraagType" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="vraagOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>TODO</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="vraagType" type="vraagType" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>De type van de vraag * `technische_vraag` - Technische vraag technische vragen over een agendapunt
+* `mondelinge_politieke_vraag` - Mondelinge politieke vraag
+* `schriftelijke_politieke_vraag` - Schriftelijke politieke vraag
+.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="stem">
 		<xsd:all>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="keuzeStemming" type="stemKeuze" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="gegevenOpStemming" type="stemming" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="keuzeStemming" type="stemKeuze" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gegevenOpStemming" type="stemming" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>TODO</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:all>
 	</xsd:complexType>
 	<xsd:complexType name="gremium">
 		<xsd:all>
-			<xsd:element name="gremiumIdentificatie" type="xsd:string" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="gremiumNaam" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="gremiumIdentificatie" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De identificatie van een gremium De identificatie van een gremium.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gremiumNaam" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van het gremium. Hier horen ook de (raads- en staten)commissies bij.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:all>
 	</xsd:complexType>
 	<xsd:complexType name="gemeente">
 		<xsd:sequence>
-			<xsd:element name="gemeentecode" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="gemeentenaam" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="gemeentecode" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De code van een gemeente in de landelijke tabel.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gemeentenaam" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van de gemeente.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
 	<xsd:complexType name="waterschap">
 		<xsd:sequence>
-			<xsd:element name="waterschapcode" type="xsd:string" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="waterschapnaam" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="waterschapcode" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De code van het waterschap in de CBS tabel.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="waterschapnaam" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van het waterschap.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
-	<complexType name="bestuurslaag">
-		<choice>
-			<element name="waterschap" type="waterschap"/>
-			<element name="provincie" type="provincie"/>
-			<element name="gemeente" type="gemeente"/>
-		</choice>
-	</complexType>
+	<xsd:complexType name="bestuurslaag">
+		<xsd:choice>
+			<xsd:element name="waterschap" type="waterschap"/>
+			<xsd:element name="provincie" type="provincie"/>
+			<xsd:element name="gemeente" type="gemeente"/>
+		</xsd:choice>
+	</xsd:complexType>
 	<xsd:simpleType name="vraagType">
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="Technische vraag"/>

--- a/ORI.xsd
+++ b/ORI.xsd
@@ -1,502 +1,501 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://vng.nl/projecten/open-raadsinformatie" targetNamespace="https://vng.nl/projecten/open-raadsinformatie" elementFormDefault="qualified" version="v0.0.1">
-	<xsd:element name="ORI" type="ORI"/>
-	<xsd:complexType name="ORI">
-		<xsd:sequence>
-			<xsd:element name="vergadering" type="vergadering" minOccurs="0" maxOccurs="unbounded">
-			  <xsd:annotation>
-				<!-- Misschien handig om de relaties te documenteren? voor informatieobject is dit al gedaan -->
-				<xsd:documentation>Een bijeenkomst waarin een of meer agendapunten worden besproken.</xsd:documentation>
-				
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="agendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Een onderdeel van de agenda dat als één geheel wordt behandeld. Een agendapunt kan weer onderverdeeld zijn in subagendapunten.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="stemming" type="stemming" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Een moment waarop aanwezige deelnemers een stemming uitbrengen over een bepaald agendapunt of vergaderstuk.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="besluit" type="besluit" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Een na beraadslaging vastgestelde beslissing.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="indiener" type="indiener" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>De indiener, zijnde een natuurlijk persoon of een organisatorische eenheid, van een informatieobject.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="organisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Een functioneel afgebakend onderdeel binnen een organisatie die verantwoordelijk is voor het indienen van een informatieobject.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="zaak" type="zaak" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="informatieobject" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>
-					<![CDATA[
-					Een op zichzelf staand geheel van gegevens met een eigen identiteit, inclusief
-					bijbehorende metadata ontvangen of gecreëerd door een natuurlijke en/of
-					rechtspersoon bij de uitvoering van diens taken.
+    <xsd:element name="ORI" type="ORI"/>
+    <xsd:complexType name="ORI">
+        <xsd:sequence>
+            <xsd:element name="vergadering" type="vergadering" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <!-- Misschien handig om de relaties te documenteren? voor informatieobject is dit al gedaan -->
+                <xsd:documentation>Een bijeenkomst waarin een of meer agendapunten worden besproken.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="agendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Een onderdeel van de agenda dat als één geheel wordt behandeld. Een agendapunt kan weer onderverdeeld zijn in subagendapunten.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="stemming" type="stemming" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Een moment waarop aanwezige deelnemers een stemming uitbrengen over een bepaald agendapunt of vergaderstuk.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="besluit" type="besluit" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Een na beraadslaging vastgestelde beslissing.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="indiener" type="indiener" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>De indiener, zijnde een natuurlijk persoon of een organisatorische eenheid, van een informatieobject.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="organisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Een functioneel afgebakend onderdeel binnen een organisatie die verantwoordelijk is voor het indienen van een informatieobject.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="zaak" type="zaak" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="informatieobject" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>
+                    <![CDATA[
+                    Een op zichzelf staand geheel van gegevens met een eigen identiteit, inclusief
+                    bijbehorende metadata ontvangen of gecreëerd door een natuurlijke en/of
+                    rechtspersoon bij de uitvoering van diens taken.
 
-					Een informatieobject is altijd gekoppeld aan minimaal een van de volgende objecten:
-					  * Vergadering
-					  * Agendapunt
-					  * Stemming
-					]]>
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="enkelvoudigInformatieobject" type="enkelvoudigInformatieobject" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="motie" type="motie" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="amendement" type="amendement" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="voorstel" type="voorstel" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="ingekomenStuk" type="ingekomenStuk" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="vraag" type="vraag" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="antwoord" type="antwoord" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="toezegging" type="toezegging" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Bij een `besluit` kan een additionele toezegging gedaan worden.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="mededeling" type="mededeling" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="natuurlijkPersoon" type="natuurlijkPersoon" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="aanwezigeDeelnemer" type="aanwezigeDeelnemer" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>De NATUURLIJKe `persoon` die deelneemt aan een `vergadering`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="dagelijksBestuur" type="dagelijksBestuur" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Het dagelijkse bestuur van de gemeente (college) of provincie (gedeputeerde staten) bereidt het beleid voor en voert dit beleid uit.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="fractie" type="fractie" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Deel van een gekozen volksvertegenwoordiging.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="mediabron" type="mediabron" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Verwijzing naar de mediabron waarin het `spreekfragment` is vastgelegd.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="vergadering">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Uniek identificatie kenmerk van de vergadering.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naam van de vergadering.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="vergaderToelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Toelichting of nadere omschrijving van de vergadering.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="georganiseerdDoorGremium" type="gremium" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Het gremium dat de vergadering georganiseerd heeft.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="vergaderingstype" type="vergaderingstype" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-				  <xsd:documentation>
-					De type-aanduiding van de **vergadering**.
+                    Een informatieobject is altijd gekoppeld aan minimaal een van de volgende objecten:
+                      * Vergadering
+                      * Agendapunt
+                      * Stemming
+                    ]]>
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="enkelvoudigInformatieobject" type="enkelvoudigInformatieobject" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="motie" type="motie" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="amendement" type="amendement" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="voorstel" type="voorstel" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ingekomenStuk" type="ingekomenStuk" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="vraag" type="vraag" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="antwoord" type="antwoord" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="toezegging" type="toezegging" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Bij een `besluit` kan een additionele toezegging gedaan worden.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="mededeling" type="mededeling" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="natuurlijkPersoon" type="natuurlijkPersoon" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="aanwezigeDeelnemer" type="aanwezigeDeelnemer" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>De NATUURLIJKe `persoon` die deelneemt aan een `vergadering`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="dagelijksBestuur" type="dagelijksBestuur" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Het dagelijkse bestuur van de gemeente (college) of provincie (gedeputeerde staten) bereidt het beleid voor en voert dit beleid uit.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="fractie" type="fractie" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Deel van een gekozen volksvertegenwoordiging.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="mediabron" type="mediabron" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Verwijzing naar de mediabron waarin het `spreekfragment` is vastgelegd.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="vergadering">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Uniek identificatie kenmerk van de vergadering.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naam van de vergadering.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="vergaderToelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Toelichting of nadere omschrijving van de vergadering.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="georganiseerdDoorGremium" type="gremium" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Het gremium dat de vergadering georganiseerd heeft.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="vergaderingstype" type="vergaderingstype" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    De type-aanduiding van de **vergadering**.
 
                     Mogelijke type:
-					  - `raadsvergadering`
-					  - `commissievergadering`
-					  - presidium
-					  - statenvergadering
-					  - algemene bestuursvergadering
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="locatie" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Omschrijving van de locatie waar de vergadering wordt gehouden.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="status" type="vergaderingStatus" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="geplandeVergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De geplande datum van de vergadering.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="vergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum van de vergadering.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="geplandeAanvangVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De geplande datum en tijdstip waarop de vergadering start.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="geplandeEindeVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De geplande datum en tijdstip waarop de vergadering eindigt.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="aanvangVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum en tijdstip waarop de vergadering is gestart Komt zeker voor als Einde vergadering ook is ingevuld.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="eindeVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum en tijdstip waarop de vergadering is geëindigd.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="publicatiedatum" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Meest recente publicatiedatum van een vergadering.
-					De datum waarop de vergadering voor het laatst gepubliceerd is. Het kan zijn dat er wijzigingen hebben plaatsgevonden en dat de vergadering opnieuw is gepubliceerd. Dit veld bevat de meest recente publicatiedatum.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Geeft aan welke bestuurslaag de verantwoordelijk die de vergadering geiniteerd heeft. TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="isVastgelegdMiddels" type="mediabron" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="isGenotuleerdIn" type="informatieobject" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="heeftAlsBijlage" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="heeftAlsDeelvergadering" type="vergadering" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="agendapunt">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="agendapuntOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De omschrijving van het agendapunt.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="geplandAgendapuntVolgnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Dit is het geplande volgnummer van het `agendapunt` van een vergadering.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="agendapuntVolgnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Dit is het volgnummer van het `agendapunt` tijdens de vergadering. Dit is de letterlijke volgorde en zegt niets over hoe dit volgnummer getoond wordt. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="geplandeEindtijd" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De geplande datum en tijdstip waarop de behandeling van de agendapunt eindigt.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="geplandeStarttijd" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De geplande datum en tijdstip waarop de behandeling van de agendapunt start.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="starttijd" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum en tijdstip waarop de behandeling van de agendapunt is gestart.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="eindtijd" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum en tijdstip waarop de behandeling van de agendapunt is geëindigd. Moet voorkomen als Starttijd voorkomt.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="agendapuntKenmerk" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De weergave van het Agendapuntvolgnummer op de agenda. Dit is de letterlijke volgorde van een Agendapunt wordt bij gehouden d.m.v. attribuut 'Agendapuntvolgnummer'. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="agendapuntTitel" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De titel of onderwerp van het agendapunt.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="indicatieHamerstuk" type="xsd:boolean" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="indicatorBehandeld" type="xsd:boolean" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Indicator geeft aan of het `agendapunt` is behandeld tijdens de `vergadering`. Is eventueel af te leiden als Starttijd en/of Eindtijd zijn ingevuld.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="indicatorBesloten" type="xsd:boolean" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Indicator of een `agendapunt` besloten wordt behandeld.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="wordtBehandeldTijdens" type="vergadering" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="heeftAlsSubagendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="heeftBehandelendAmbtenaar" type="natuurlijkPersoon" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="heeftAlsBijlage" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="spreekfragment">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="aanvangSpreekfragment" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Het tijdstip en de datum van aanvang van het `spreekfragment`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="eindeSpreekfragment" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Het tijdstip en de datum van einde van het `spreekfragment`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="taal" type="xsd:language" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De taal van het informatieobject. Bij voorkeur aaangeduid volgens `iso` 639-2/`b`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="tekstSpreekfragment" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De uitgeschreven weergave van het `spreekfragment`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="titelSpreekfragment" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De titel die kenmerkend is voor het `spreekfragment` of deel van de discussie.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="positieNotulen" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De positie van het `spreekfragment` binnen de notulen.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="audioTijdsaanduidingAanvang" type="xsd:integer" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De tijdsaanduiding van de aanvang van het `spreekfragment` in de audio opname in seconden.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="audioTijdsaanduidingEinde" type="xsd:integer" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De tijdsaanduiding van het einde van het `spreekfragment` in de audio opname in seconden.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="videoTijdsaanduidingAanvang" type="xsd:integer" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De tijdsaanduiding van de aanvang van het `spreekfragment` in de video opname in seconden.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="videoTijdsaanduidingEinde" type="xsd:integer" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De tijdsaanduiding van het einde van het `spreekfragment` in de video opname in seconden.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="isVastgelegdIn" type="mediabron" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="spreektTijdens" type="agendapunt" minOccurs="1" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="stemming">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="stemmingstype" type="stemmingstype" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-				  <xsd:documentation>
+                      - `raadsvergadering`
+                      - `commissievergadering`
+                      - presidium
+                      - statenvergadering
+                      - algemene bestuursvergadering
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="locatie" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Omschrijving van de locatie waar de vergadering wordt gehouden.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="status" type="vergaderingStatus" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="geplandeVergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De geplande datum van de vergadering.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="vergaderdatum" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum van de vergadering.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="geplandeAanvangVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De geplande datum en tijdstip waarop de vergadering start.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="geplandeEindeVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De geplande datum en tijdstip waarop de vergadering eindigt.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="aanvangVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum en tijdstip waarop de vergadering is gestart Komt zeker voor als Einde vergadering ook is ingevuld.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="eindeVergadering" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum en tijdstip waarop de vergadering is geëindigd.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="publicatiedatum" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Meest recente publicatiedatum van een vergadering.
+                    De datum waarop de vergadering voor het laatst gepubliceerd is. Het kan zijn dat er wijzigingen hebben plaatsgevonden en dat de vergadering opnieuw is gepubliceerd. Dit veld bevat de meest recente publicatiedatum.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Geeft aan welke bestuurslaag de verantwoordelijk die de vergadering geiniteerd heeft. TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="isVastgelegdMiddels" type="mediabron" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="isGenotuleerdIn" type="informatieobject" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="heeftAlsBijlage" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="heeftAlsDeelvergadering" type="vergadering" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="agendapunt">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="agendapuntOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De omschrijving van het agendapunt.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="geplandAgendapuntVolgnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Dit is het geplande volgnummer van het `agendapunt` van een vergadering.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="agendapuntVolgnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Dit is het volgnummer van het `agendapunt` tijdens de vergadering. Dit is de letterlijke volgorde en zegt niets over hoe dit volgnummer getoond wordt. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="geplandeEindtijd" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De geplande datum en tijdstip waarop de behandeling van de agendapunt eindigt.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="geplandeStarttijd" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De geplande datum en tijdstip waarop de behandeling van de agendapunt start.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="starttijd" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum en tijdstip waarop de behandeling van de agendapunt is gestart.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="eindtijd" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum en tijdstip waarop de behandeling van de agendapunt is geëindigd. Moet voorkomen als Starttijd voorkomt.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="agendapuntKenmerk" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De weergave van het Agendapuntvolgnummer op de agenda. Dit is de letterlijke volgorde van een Agendapunt wordt bij gehouden d.m.v. attribuut 'Agendapuntvolgnummer'. Hoe het Agendapunt getoond wordt op de Agenda wordt beschreven met attribuut 'Agendapunt kenmerk'.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="agendapuntTitel" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De titel of onderwerp van het agendapunt.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="indicatieHamerstuk" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="indicatorBehandeld" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Indicator geeft aan of het `agendapunt` is behandeld tijdens de `vergadering`. Is eventueel af te leiden als Starttijd en/of Eindtijd zijn ingevuld.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="indicatorBesloten" type="xsd:boolean" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Indicator of een `agendapunt` besloten wordt behandeld.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="wordtBehandeldTijdens" type="vergadering" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="heeftAlsSubagendapunt" type="agendapunt" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="heeftBehandelendAmbtenaar" type="natuurlijkPersoon" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="heeftAlsBijlage" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="spreekfragment">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="aanvangSpreekfragment" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Het tijdstip en de datum van aanvang van het `spreekfragment`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="eindeSpreekfragment" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Het tijdstip en de datum van einde van het `spreekfragment`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="taal" type="xsd:language" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De taal van het informatieobject. Bij voorkeur aaangeduid volgens `iso` 639-2/`b`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="tekstSpreekfragment" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De uitgeschreven weergave van het `spreekfragment`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="titelSpreekfragment" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De titel die kenmerkend is voor het `spreekfragment` of deel van de discussie.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="positieNotulen" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De positie van het `spreekfragment` binnen de notulen.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="audioTijdsaanduidingAanvang" type="xsd:integer" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De tijdsaanduiding van de aanvang van het `spreekfragment` in de audio opname in seconden.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="audioTijdsaanduidingEinde" type="xsd:integer" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De tijdsaanduiding van het einde van het `spreekfragment` in de audio opname in seconden.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="videoTijdsaanduidingAanvang" type="xsd:integer" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De tijdsaanduiding van de aanvang van het `spreekfragment` in de video opname in seconden.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="videoTijdsaanduidingEinde" type="xsd:integer" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De tijdsaanduiding van het einde van het `spreekfragment` in de video opname in seconden.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="isVastgelegdIn" type="mediabron" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="spreektTijdens" type="agendapunt" minOccurs="1" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="stemming">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="stemmingstype" type="stemmingstype" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                  <xsd:documentation>
                   Duiding van het type van een `stemming`
 
                   * `hoofdelijk` - Hoofdelijk
                   * `regulier` - Regulier
                   * `schriftelijk` - Schriftelijk
                   </xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="resultaatMondelingeStemming" type="stemmingResultaat" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="resultaatStemmingOverPersonen" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Het resultaat van de stemming over één of meerdere personen.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="stemmingOverPersonen" type="stemmingOverPersonen" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De individuele uitgebrachte STEMmen over personen zijn geheim. Alleen het aantal uitgebrachte stemmen per kandidaat is bekend.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="heeftBetrekkingOpAgendapunt" type="agendapunt" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="heeftBetrekkingOpBesluitvormingsstuk" type="besluitvormingsstuk" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="leidtTotBesluit" type="besluit" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="mediabron">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="locatieWebVTTBestand" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De locatie waar het Webvttbestand is opgeslagen.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="mimetype" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Het type bestand dat is opgeslagen.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="mediabronType" type="mediabronType" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>* `video` - Video technische vragen over een agendapunt
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="resultaatMondelingeStemming" type="stemmingResultaat" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="resultaatStemmingOverPersonen" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Het resultaat van de stemming over één of meerdere personen.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="stemmingOverPersonen" type="stemmingOverPersonen" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De individuele uitgebrachte STEMmen over personen zijn geheim. Alleen het aantal uitgebrachte stemmen per kandidaat is bekend.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="heeftBetrekkingOpAgendapunt" type="agendapunt" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="heeftBetrekkingOpBesluitvormingsstuk" type="besluitvormingsstuk" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="leidtTotBesluit" type="besluit" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="mediabron">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="locatieWebVTTBestand" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De locatie waar het Webvttbestand is opgeslagen.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="mimetype" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Het type bestand dat is opgeslagen.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="mediabronType" type="mediabronType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>* `video` - Video technische vragen over een agendapunt
 * `audio` - Audio
 * `transcriptie` - Transcriptie
 .</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="URL" type="xsd:anyURI" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="natuurlijkPersoon">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="geslachtsaanduiding" type="geslacht" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="functie" type="functie" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>* `burgemeester` - Burgemeester van de gemeente
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="URL" type="xsd:anyURI" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="natuurlijkPersoon">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="geslachtsaanduiding" type="geslacht" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="functie" type="functie" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>* `burgemeester` - Burgemeester van de gemeente
 * `wethouder` - Wethouder van de gemeente
 * `raadslid` - Raadslid van de gemeente
 * `burgerlid` - Burgerlid
@@ -514,171 +513,171 @@
 * `algemeen_bestuurslid` - Algemeen bestuurslid Waterschappen
 * `secretarisdirecteur` - Secretarisdirecteur Waterschappen
 .</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="naamNatuurlijkPersoon" type="naamNatuurlijkPersoon" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naam van een natuurlijk persoon. Wanneer de naam bij het invullen niet opgesplitst is in voornamen, tussenvoegsel en achternaam kan de naam ook in één keer worden geregistreerd in het veld volledigeNaam.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="nevenfunctieNatuurlijkPersoon" type="nevenfunctieNatuurlijkPersoon" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="isLidVanFractie" type="fractielidmaatschap" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="isLidVanDagelijksBestuur" type="dagelijksBestuurLidmaatschap" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="naamNatuurlijkPersoon">
-		<xsd:sequence>
-			<xsd:element name="achternaam" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De achternaam van een `natuurlijk persoon`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="tussenvoegsel" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De tussenvoegsel van een `natuurlijk persoon`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="voorletters" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De voorletters van een `natuurlijk persoon`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="voornamen" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De voornamen van een `natuurlijk persoon`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="volledigeNaam" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De volledige naam van een `natuurlijk persoon`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="nevenfunctieNatuurlijkPersoon">
-		<xsd:sequence>
-			<xsd:element name="omschrijvingNevenfunctie" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="naamOrganisatieNevenfunctie" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naam van de organisatie van de nevenfunctie.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="aantalUrenperMaand" type="xsd:integer" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Het aantal uren dat per maand besteed wordt aan de nevenfunctie.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="indicatorBezoldigd" type="xsd:boolean" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Indicator of de nevenfunctie uitgevoerd wordt tegen betaling.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="indicatorNevenfunctieVanwegeLidmaatschap" type="xsd:boolean" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="datumMelding" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum waarop de nevenfunctie gemeld is bij de griffier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="datumAanvangNevenfunctie" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum van aanvang van de nevenfunctie.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="datumEindeNevenfunctie" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum van het einde van de nevenfunctie.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="organisatorischeEenheid">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="e-mailadres" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Elektronisch postadres waaronder de organisatorische eenheid in de regel bereikbaar is.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="faxnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Faxnummer waaronder de organisatorische eenheid in de regel bereikbaar is.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De feitelijke naam van de organisatorische eenheid.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="naamVerkort" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Een verkorte naam voor de organisatorische eenheid.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="omschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Een omschrijving van de organisatorische eenheid.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="telefoonnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Telefoonnummer waaronder de organisatorische eenheid in de regel bereikbaar is.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="toelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Toelichting bij de organisatorische eenheid.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="stemmingOverPersonen">
-		<xsd:sequence>
-			<xsd:element name="naamKandidaat" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naam van de kandidaat over wie gestemd is.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="aantalUitgebrachteStemmen" type="xsd:integer" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Het aantal uitgebracht stemmen behorend bij een kandidaat.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="aanwezigeDeelnemer">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="rolNaam" type="rolNaam" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Duiding van de rollen van een natuurlijke persoon tijdens een vergadering* `voorzitter` - Voorzitter de voorzitter zit de vergadering voor
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="naamNatuurlijkPersoon" type="naamNatuurlijkPersoon" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naam van een natuurlijk persoon. Wanneer de naam bij het invullen niet opgesplitst is in voornamen, tussenvoegsel en achternaam kan de naam ook in één keer worden geregistreerd in het veld volledigeNaam.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="nevenfunctieNatuurlijkPersoon" type="nevenfunctieNatuurlijkPersoon" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="isLidVanFractie" type="fractielidmaatschap" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="isLidVanDagelijksBestuur" type="dagelijksBestuurLidmaatschap" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="naamNatuurlijkPersoon">
+        <xsd:sequence>
+            <xsd:element name="achternaam" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De achternaam van een `natuurlijk persoon`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="tussenvoegsel" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De tussenvoegsel van een `natuurlijk persoon`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="voorletters" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De voorletters van een `natuurlijk persoon`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="voornamen" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De voornamen van een `natuurlijk persoon`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="volledigeNaam" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De volledige naam van een `natuurlijk persoon`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="nevenfunctieNatuurlijkPersoon">
+        <xsd:sequence>
+            <xsd:element name="omschrijvingNevenfunctie" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="naamOrganisatieNevenfunctie" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naam van de organisatie van de nevenfunctie.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="aantalUrenperMaand" type="xsd:integer" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Het aantal uren dat per maand besteed wordt aan de nevenfunctie.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="indicatorBezoldigd" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Indicator of de nevenfunctie uitgevoerd wordt tegen betaling.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="indicatorNevenfunctieVanwegeLidmaatschap" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="datumMelding" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum waarop de nevenfunctie gemeld is bij de griffier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="datumAanvangNevenfunctie" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum van aanvang van de nevenfunctie.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="datumEindeNevenfunctie" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum van het einde van de nevenfunctie.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="organisatorischeEenheid">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="e-mailadres" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Elektronisch postadres waaronder de organisatorische eenheid in de regel bereikbaar is.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="faxnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Faxnummer waaronder de organisatorische eenheid in de regel bereikbaar is.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De feitelijke naam van de organisatorische eenheid.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="naamVerkort" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Een verkorte naam voor de organisatorische eenheid.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="omschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Een omschrijving van de organisatorische eenheid.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="telefoonnummer" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Telefoonnummer waaronder de organisatorische eenheid in de regel bereikbaar is.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="toelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Toelichting bij de organisatorische eenheid.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="stemmingOverPersonen">
+        <xsd:sequence>
+            <xsd:element name="naamKandidaat" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naam van de kandidaat over wie gestemd is.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="aantalUitgebrachteStemmen" type="xsd:integer" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Het aantal uitgebracht stemmen behorend bij een kandidaat.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="aanwezigeDeelnemer">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="rolNaam" type="rolNaam" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Duiding van de rollen van een natuurlijke persoon tijdens een vergadering* `voorzitter` - Voorzitter de voorzitter zit de vergadering voor
 * `vice_voorzitter` - Vice voorzitter de vice-voorzitter van de vergadering
 * `raadslid` - Raadslid Een raadslid is een gekozen volksvertegenwoordiger binnen een gemeente. Alle raadsleden van één gemeente vormen samen de gemeenteraad van de betreffende gemeente.
 * `inspreker` - Inspreker Een inspreker is een belanghebbende of betrokkene die wil inspreken bij een agendapunt
@@ -689,686 +688,686 @@
 * `algemeen_bestuurslid` - Algemeen bestuurslid Waterschappen
 * `griffier` - Griffier van de vergadering
 .</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="organisatie" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naam van de organisatie die wordt vertegenwoordigd door de aanwezige deelnemer.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="deelnemerspositie" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De plek waar een deelnemer in de zaal zit. Dit kan bijvoorbeeld een stoel of een console zijn. Dit kan o.a. van belang zijn voor de audio/video-verslaggeving.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="aanvangAanwezigheid" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De aanvang van de aanwezigheid.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="eindeAanwezigheid" type="xsd:time" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De einde van de aanwezigheid.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="neemtDeelAanVergadering" type="vergadering" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="isNatuurlijkPersoon" type="natuurlijkPersoon" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="neemtDeelAanStemming" type="stem" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="spreektTijdens" type="spreekfragment" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="dagelijksBestuurLidmaatschap">
-		<xsd:all>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="datumBeginDagelijkseBestuurLidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="datumEindeDagelijkseBestuurLidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="dagelijksBestuur" type="dagelijksBestuur" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Verwijzing naar het dagelijks bestuur.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:all>
-	</xsd:complexType>
-	<xsd:complexType name="dagelijksBestuur">
-		<xsd:all>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>`id` van de resource waarnaar verwezen wordt.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="dagelijksBestuursnaam" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Naam van het dagelijks bestuur.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="dagelijksBestuurstype" type="dagelijksBestuurstype" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:all>
-	</xsd:complexType>
-	<xsd:complexType name="zaak">
-		<xsd:sequence>
-			<xsd:element name="zaakID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="zaakregistratie" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Identificatie van de registratie waar de zaak is vastgelegd.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="omschrijving" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Omschrijving van de zaak.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="informatieobject">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="titel" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De titel van het informatieobject.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="bronorganisatie" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Bronorganisatie. De in het `nhr` voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="versie" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Versie. Alle alfanumerieke tekens m.u.v. diacrieten.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="auteur" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de `zaak` gerelateerd is, dan wel, indien de auteur niet in een rol aan de `zaak` gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="creatiedatum" type="xsd:date" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Creatiedatum. Alle geldige datums gelegen op of voor de huidige datum en tijd.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="link" type="xsd:anyURI" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De `url` waarmee de inhoud van het informatieobject op te vragen is.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="vertrouwelijkheidsaanduiding" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Aanduiding van de vertrouwelijkheid.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="zaken" type="zaak" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>Zaken die gerelateerd zijn aan dit informatieobject.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="enkelvoudigInformatieobject">
-		<xsd:complexContent>
-			<xsd:extension base="informatieobject">
-				<xsd:sequence>
-					<xsd:element name="taal" type="xsd:language" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>De taal van het informatieobject. Bij voorkeur aaangeduid volgens `iso` 639-2/`b`.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="inhoud" type="xsd:string" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>Inhoud van het document De content (data) van het enkelvoudig informatieobject in het formaat zoals gespecificeerd met de attribuutsoort 'Formaat'.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="motie">
-		<xsd:complexContent>
-			<xsd:extension base="besluitvormingsstuk">
-				<xsd:sequence>
-					<xsd:element name="motieType" type="motieType" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>Duiding van het type van een `motie`* `voorstel` - Voorstel voorstellen van het college van `b`&amp;`w` (gemeente) of van de gedeputueerde staten (provincie) en initiatiefvoorstellen van raadsleden (gemeente) of statenleden (provincie)
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="organisatie" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naam van de organisatie die wordt vertegenwoordigd door de aanwezige deelnemer.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="deelnemerspositie" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De plek waar een deelnemer in de zaal zit. Dit kan bijvoorbeeld een stoel of een console zijn. Dit kan o.a. van belang zijn voor de audio/video-verslaggeving.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="aanvangAanwezigheid" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De aanvang van de aanwezigheid.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="eindeAanwezigheid" type="xsd:time" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De einde van de aanwezigheid.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="neemtDeelAanVergadering" type="vergadering" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="isNatuurlijkPersoon" type="natuurlijkPersoon" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="neemtDeelAanStemming" type="stem" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="spreektTijdens" type="spreekfragment" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="dagelijksBestuurLidmaatschap">
+        <xsd:all>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="datumBeginDagelijkseBestuurLidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="datumEindeDagelijkseBestuurLidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="dagelijksBestuur" type="dagelijksBestuur" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Verwijzing naar het dagelijks bestuur.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:all>
+    </xsd:complexType>
+    <xsd:complexType name="dagelijksBestuur">
+        <xsd:all>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>`id` van de resource waarnaar verwezen wordt.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="dagelijksBestuursnaam" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Naam van het dagelijks bestuur.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="dagelijksBestuurstype" type="dagelijksBestuurstype" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:all>
+    </xsd:complexType>
+    <xsd:complexType name="zaak">
+        <xsd:sequence>
+            <xsd:element name="zaakID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="zaakregistratie" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Identificatie van de registratie waar de zaak is vastgelegd.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="omschrijving" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Omschrijving van de zaak.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="informatieobject">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="titel" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De titel van het informatieobject.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="bronorganisatie" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Bronorganisatie. De in het `nhr` voorkomende unieke identificaties van rechtspersonen en samenwerkingsverbanden.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="versie" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Versie. Alle alfanumerieke tekens m.u.v. diacrieten.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="auteur" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naamgegevens van de auteur zijnde een betrokkene die in een rol aan de `zaak` gerelateerd is, dan wel, indien de auteur niet in een rol aan de `zaak` gerelateerd is, de naamgegevens van de natuurlijk persoon of organisatie zijnde de auteur. In het laatste geval verdient het aanbeveling om aanvullend te vermelden uit welken hoofde het auteurschap wordt uitgeoefend.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="creatiedatum" type="xsd:date" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Creatiedatum. Alle geldige datums gelegen op of voor de huidige datum en tijd.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="link" type="xsd:anyURI" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De `url` waarmee de inhoud van het informatieobject op te vragen is.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="vertrouwelijkheidsaanduiding" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Aanduiding van de vertrouwelijkheid.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="zaken" type="zaak" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Zaken die gerelateerd zijn aan dit informatieobject.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="enkelvoudigInformatieobject">
+        <xsd:complexContent>
+            <xsd:extension base="informatieobject">
+                <xsd:sequence>
+                    <xsd:element name="taal" type="xsd:language" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>De taal van het informatieobject. Bij voorkeur aaangeduid volgens `iso` 639-2/`b`.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="inhoud" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Inhoud van het document De content (data) van het enkelvoudig informatieobject in het formaat zoals gespecificeerd met de attribuutsoort 'Formaat'.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="motie">
+        <xsd:complexContent>
+            <xsd:extension base="besluitvormingsstuk">
+                <xsd:sequence>
+                    <xsd:element name="motieType" type="motieType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Duiding van het type van een `motie`* `voorstel` - Voorstel voorstellen van het college van `b`&amp;`w` (gemeente) of van de gedeputueerde staten (provincie) en initiatiefvoorstellen van raadsleden (gemeente) of statenleden (provincie)
 * `afkeuring` - Afkeuring
 * `treurnis` - Treurnis
 * `wantrouwen` - Wantrouwen
 * `vreemd` - Vreemd
 * `overig` - Overig Dit is de standaardwaarde
 .</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="toezegging">
-		<xsd:complexContent>
-			<xsd:extension base="enkelvoudigInformatieobject">
-				<xsd:sequence>
-					<xsd:element name="toezeggingsOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>TODO</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="antwoord">
-		<xsd:complexContent>
-			<xsd:extension base="enkelvoudigInformatieobject">
-				<xsd:sequence>
-					<xsd:element name="antwoordOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>TODO</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="behorendBijVraag" type="vraag" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>TODO</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="voorstel">
-		<xsd:complexContent>
-			<xsd:extension base="besluitvormingsstuk">
-				<xsd:sequence>
-					<xsd:element name="portefeuillehouder" type="xsd:string" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>De naam van de portefeuillehouder van het `voorstel`.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="isIngediendDoor" type="dagelijksBestuur" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>TODO</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="mededeling">
-		<xsd:complexContent>
-			<xsd:extension base="enkelvoudigInformatieobject">
-				<xsd:sequence>
-					<xsd:element name="mededelingOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>TODO</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="ingekomenStuk">
-		<xsd:complexContent>
-			<xsd:extension base="enkelvoudigInformatieobject"/>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="amendement">
-		<xsd:complexContent>
-			<xsd:extension base="besluitvormingsstuk">
-				<xsd:sequence>
-					<xsd:element name="toelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>De toelichting op het `amendement`.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="hoortBijVoorstel" type="voorstel" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>TODO</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="subamendementVan" type="amendement" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>TODO</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="besluit">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="besluitToelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Toelichting bij het besluit.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="toezegging" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Bij een `besluit` kan een additionele toezegging gedaan worden.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="besluitResultaat" type="besluitResultaat" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Het resultaat van het `besluit`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="indiener">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Uniek identificatie kenmerk van de vergadering.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De benaming van de indiener.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="adresBinnenland" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De aanduiding van het adres van de indiener.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="heeftIngediend" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="isNatuurlijkPersoon" type="natuurlijkPersoon" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="isOrganisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="besluitvormingsstuk" abstract="true">
-		<xsd:complexContent>
-			<xsd:extension base="enkelvoudigInformatieobject">
-				<xsd:sequence>
-					<xsd:element name="omschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>TODO</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="datumIngediend" type="xsd:date" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>De datum waarop het `besluitvormingsstuk` is ingediend.</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="fractie">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="fractienaam" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naam van de fractie.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="fractieNeemtDeelAanStemming" type="stemresultaatPerFractie" minOccurs="0" maxOccurs="unbounded">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="stemresultaatPerFractie">
-		<xsd:all>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="fractieStemresultaat" type="fractieStemresultaat" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>* `aangenomen` - Aangenomen de gehele aanwezige fractie heeft voor gestemd
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="toezegging">
+        <xsd:complexContent>
+            <xsd:extension base="enkelvoudigInformatieobject">
+                <xsd:sequence>
+                    <xsd:element name="toezeggingsOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>TODO</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="antwoord">
+        <xsd:complexContent>
+            <xsd:extension base="enkelvoudigInformatieobject">
+                <xsd:sequence>
+                    <xsd:element name="antwoordOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>TODO</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="behorendBijVraag" type="vraag" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>TODO</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="voorstel">
+        <xsd:complexContent>
+            <xsd:extension base="besluitvormingsstuk">
+                <xsd:sequence>
+                    <xsd:element name="portefeuillehouder" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>De naam van de portefeuillehouder van het `voorstel`.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="isIngediendDoor" type="dagelijksBestuur" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>TODO</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="mededeling">
+        <xsd:complexContent>
+            <xsd:extension base="enkelvoudigInformatieobject">
+                <xsd:sequence>
+                    <xsd:element name="mededelingOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>TODO</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="ingekomenStuk">
+        <xsd:complexContent>
+            <xsd:extension base="enkelvoudigInformatieobject"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="amendement">
+        <xsd:complexContent>
+            <xsd:extension base="besluitvormingsstuk">
+                <xsd:sequence>
+                    <xsd:element name="toelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>De toelichting op het `amendement`.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="hoortBijVoorstel" type="voorstel" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>TODO</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="subamendementVan" type="amendement" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>TODO</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="besluit">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="besluitToelichting" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Toelichting bij het besluit.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="toezegging" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Bij een `besluit` kan een additionele toezegging gedaan worden.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="besluitResultaat" type="besluitResultaat" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Het resultaat van het `besluit`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="indiener">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Uniek identificatie kenmerk van de vergadering.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="naam" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De benaming van de indiener.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="adresBinnenland" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De aanduiding van het adres van de indiener.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="heeftIngediend" type="informatieobject" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="isNatuurlijkPersoon" type="natuurlijkPersoon" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="isOrganisatorischeEenheid" type="organisatorischeEenheid" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="besluitvormingsstuk" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="enkelvoudigInformatieobject">
+                <xsd:sequence>
+                    <xsd:element name="omschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>TODO</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="datumIngediend" type="xsd:date" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>De datum waarop het `besluitvormingsstuk` is ingediend.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="fractie">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="fractienaam" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naam van de fractie.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="bestuurslaag" type="bestuurslaag" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="fractieNeemtDeelAanStemming" type="stemresultaatPerFractie" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="stemresultaatPerFractie">
+        <xsd:all>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="fractieStemresultaat" type="fractieStemresultaat" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>* `aangenomen` - Aangenomen de gehele aanwezige fractie heeft voor gestemd
 * `verworpen` - Verworpen de gehele aanwezige fractie heeft tegen gestemd
 * `verdeeld` - Verdeeld de stemming in de fractie was verdeeld: een deel was voor en een deel was tegen
 .</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="gegevenOpStemming" type="stemming" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:all>
-	</xsd:complexType>
-	<xsd:complexType name="fractielidmaatschap">
-		<xsd:sequence>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="datumBeginFractielidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum en tijdstip waarop het fractie lidmaatschap begon.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="datumEindeFractielidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De datum en tijdstip waarop het fractie lidmaatschap geëindigd is.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="indicatieVoorzitter" type="xsd:boolean" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Indicatie of iemand de voorzitter is van de `fractie`.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="fractie" type="fractie" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Verwijzing naar de fractie.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="vraag">
-		<xsd:complexContent>
-			<xsd:extension base="enkelvoudigInformatieobject">
-				<xsd:sequence>
-					<xsd:element name="vraagOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>TODO</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-					<xsd:element name="vraagType" type="vraagType" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation>De type van de vraag * `technische_vraag` - Technische vraag technische vragen over een agendapunt
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="gegevenOpStemming" type="stemming" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:all>
+    </xsd:complexType>
+    <xsd:complexType name="fractielidmaatschap">
+        <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="datumBeginFractielidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum en tijdstip waarop het fractie lidmaatschap begon.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="datumEindeFractielidmaatschap" type="xsd:date" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De datum en tijdstip waarop het fractie lidmaatschap geëindigd is.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="indicatieVoorzitter" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Indicatie of iemand de voorzitter is van de `fractie`.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="fractie" type="fractie" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Verwijzing naar de fractie.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="vraag">
+        <xsd:complexContent>
+            <xsd:extension base="enkelvoudigInformatieobject">
+                <xsd:sequence>
+                    <xsd:element name="vraagOmschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>TODO</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="vraagType" type="vraagType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>De type van de vraag * `technische_vraag` - Technische vraag technische vragen over een agendapunt
 * `mondelinge_politieke_vraag` - Mondelinge politieke vraag
 * `schriftelijke_politieke_vraag` - Schriftelijke politieke vraag
 .</xsd:documentation>
-						</xsd:annotation>
-					</xsd:element>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="stem">
-		<xsd:all>
-			<xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>Unieke resource identifier.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="keuzeStemming" type="stemKeuze" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="gegevenOpStemming" type="stemming" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>TODO</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:all>
-	</xsd:complexType>
-	<xsd:complexType name="gremium">
-		<xsd:all>
-			<xsd:element name="gremiumIdentificatie" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De identificatie van een gremium De identificatie van een gremium.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="gremiumNaam" type="xsd:string" minOccurs="0" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naam van het gremium. Hier horen ook de (raads- en staten)commissies bij.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:all>
-	</xsd:complexType>
-	<xsd:complexType name="gemeente">
-		<xsd:sequence>
-			<xsd:element name="gemeentecode" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De code van een gemeente in de landelijke tabel.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="gemeentenaam" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naam van de gemeente.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="waterschap">
-		<xsd:sequence>
-			<xsd:element name="waterschapcode" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De code van het waterschap in de CBS tabel.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="waterschapnaam" type="xsd:string" minOccurs="1" maxOccurs="1">
-				<xsd:annotation>
-					<xsd:documentation>De naam van het waterschap.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="bestuurslaag">
-		<xsd:choice>
-			<xsd:element name="waterschap" type="waterschap"/>
-			<xsd:element name="provincie" type="provincie"/>
-			<xsd:element name="gemeente" type="gemeente"/>
-		</xsd:choice>
-	</xsd:complexType>
-	<xsd:simpleType name="vraagType">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Technische vraag"/>
-			<xsd:enumeration value="Mondelinge politieke vraag"/>
-			<xsd:enumeration value="Schriftelijke politieke vraag"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="besluitResultaat">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Unaniem aangenomen"/>
-			<xsd:enumeration value="Aangenomen"/>
-			<xsd:enumeration value="Geamendeerd aangenomen"/>
-			<xsd:enumeration value="Onder voorbehoud aangenomen"/>
-			<xsd:enumeration value="Verworpen"/>
-			<xsd:enumeration value="Aangehouden"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="motieType">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Voorstel"/>
-			<xsd:enumeration value="Afkeuring"/>
-			<xsd:enumeration value="Treurnis"/>
-			<xsd:enumeration value="Wantrouwen"/>
-			<xsd:enumeration value="Vreemd"/>
-			<xsd:enumeration value="Overig"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="mediabronType">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Video"/>
-			<xsd:enumeration value="Audio"/>
-			<xsd:enumeration value="Transcriptie"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="stemKeuze">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Voor"/>
-			<xsd:enumeration value="Tegen"/>
-			<xsd:enumeration value="Afwezig"/>
-			<xsd:enumeration value="Onthouden"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="fractieStemresultaat">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Aangenomen"/>
-			<xsd:enumeration value="Verworpen"/>
-			<xsd:enumeration value="Verdeeld"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="stemmingstype">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Hoofdelijk"/>
-			<xsd:enumeration value="Regulier"/>
-			<xsd:enumeration value="Schriftelijk"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="stemmingResultaat">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Voor"/>
-			<xsd:enumeration value="Tegen"/>
-			<xsd:enumeration value="Gelijk"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="besluitvormingsstukkenType">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Hamerstukken"/>
-			<xsd:enumeration value="Bespreekstukken"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="vergaderingStatus">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Gepland"/>
-			<xsd:enumeration value="Gehouden"/>
-			<xsd:enumeration value="Geannuleerd"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="vergaderingstype">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Raadsvergadering"/>
-			<xsd:enumeration value="Commissievergadering"/>
-			<xsd:enumeration value="Statenvergadering"/>
-			<xsd:enumeration value="Algemene bestuursvergadering"/>
-			<xsd:enumeration value="Presidium"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="rolNaam">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Voorzitter"/>
-			<xsd:enumeration value="Vice-voorzitter"/>
-			<xsd:enumeration value="Raadslid"/>
-			<xsd:enumeration value="Statenlid"/>
-			<xsd:enumeration value="Dagelijks bestuurslid"/>
-			<xsd:enumeration value="Algemeen bestuurslid"/>
-			<xsd:enumeration value="Inspreker"/>
-			<xsd:enumeration value="Portefeuillehouder"/>
-			<xsd:enumeration value="Griffier"/>
-			<xsd:enumeration value="Overig"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="functie">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Burgemeester"/>
-			<xsd:enumeration value="Wethouder"/>
-			<xsd:enumeration value="Raadslid"/>
-			<xsd:enumeration value="Burgerlid"/>
-			<xsd:enumeration value="Griffier"/>
-			<xsd:enumeration value="Gemeentesecretaris"/>
-			<xsd:enumeration value="Commissaris van de Koning"/>
-			<xsd:enumeration value="Gedeputeerde"/>
-			<xsd:enumeration value="Statenlid"/>
-			<xsd:enumeration value="Provinciesecretaris"/>
-			<xsd:enumeration value="Dijkgraaf"/>
-			<xsd:enumeration value="Dagelijks bestuurslid"/>
-			<xsd:enumeration value="Algemeen bestuurslid"/>
-			<xsd:enumeration value="Secretarisdirecteur"/>
-			<xsd:enumeration value="Ambtenaar/medewerker"/>
-			<xsd:enumeration value="Adviseur of deskundige"/>
-			<xsd:enumeration value="Overig"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="geslacht">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Man"/>
-			<xsd:enumeration value="Vrouw"/>
-			<xsd:enumeration value="Anders"/>
-			<xsd:enumeration value="Onbekend"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="dagelijksBestuurstype">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="College"/>
-			<xsd:enumeration value="Gedeputeerde Staten"/>
-			<xsd:enumeration value="Dagelijks bestuur"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="provincie">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="Drenthe"/>
-			<xsd:enumeration value="Groningen"/>
-			<xsd:enumeration value="Overijssel"/>
-			<xsd:enumeration value="Flevoland"/>
-			<xsd:enumeration value="Gelderland"/>
-			<xsd:enumeration value="Utrecht"/>
-			<xsd:enumeration value="Noord-Holland"/>
-			<xsd:enumeration value="Zuid-Holland"/>
-			<xsd:enumeration value="Zeeland"/>
-			<xsd:enumeration value="Noord-Brabant"/>
-			<xsd:enumeration value="Limburg"/>
-		</xsd:restriction>
-	</xsd:simpleType>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="stem">
+        <xsd:all>
+            <xsd:element name="ID" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Unieke resource identifier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="keuzeStemming" type="stemKeuze" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="gegevenOpStemming" type="stemming" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>TODO</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:all>
+    </xsd:complexType>
+    <xsd:complexType name="gremium">
+        <xsd:all>
+            <xsd:element name="gremiumIdentificatie" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De identificatie van een gremium De identificatie van een gremium.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="gremiumNaam" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naam van het gremium. Hier horen ook de (raads- en staten)commissies bij.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:all>
+    </xsd:complexType>
+    <xsd:complexType name="gemeente">
+        <xsd:sequence>
+            <xsd:element name="gemeentecode" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De code van een gemeente in de landelijke tabel.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="gemeentenaam" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naam van de gemeente.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="waterschap">
+        <xsd:sequence>
+            <xsd:element name="waterschapcode" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De code van het waterschap in de CBS tabel.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="waterschapnaam" type="xsd:string" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>De naam van het waterschap.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="bestuurslaag">
+        <xsd:choice>
+            <xsd:element name="waterschap" type="waterschap"/>
+            <xsd:element name="provincie" type="provincie"/>
+            <xsd:element name="gemeente" type="gemeente"/>
+        </xsd:choice>
+    </xsd:complexType>
+    <xsd:simpleType name="vraagType">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Technische vraag"/>
+            <xsd:enumeration value="Mondelinge politieke vraag"/>
+            <xsd:enumeration value="Schriftelijke politieke vraag"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="besluitResultaat">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Unaniem aangenomen"/>
+            <xsd:enumeration value="Aangenomen"/>
+            <xsd:enumeration value="Geamendeerd aangenomen"/>
+            <xsd:enumeration value="Onder voorbehoud aangenomen"/>
+            <xsd:enumeration value="Verworpen"/>
+            <xsd:enumeration value="Aangehouden"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="motieType">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Voorstel"/>
+            <xsd:enumeration value="Afkeuring"/>
+            <xsd:enumeration value="Treurnis"/>
+            <xsd:enumeration value="Wantrouwen"/>
+            <xsd:enumeration value="Vreemd"/>
+            <xsd:enumeration value="Overig"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="mediabronType">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Video"/>
+            <xsd:enumeration value="Audio"/>
+            <xsd:enumeration value="Transcriptie"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="stemKeuze">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Voor"/>
+            <xsd:enumeration value="Tegen"/>
+            <xsd:enumeration value="Afwezig"/>
+            <xsd:enumeration value="Onthouden"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="fractieStemresultaat">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Aangenomen"/>
+            <xsd:enumeration value="Verworpen"/>
+            <xsd:enumeration value="Verdeeld"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="stemmingstype">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Hoofdelijk"/>
+            <xsd:enumeration value="Regulier"/>
+            <xsd:enumeration value="Schriftelijk"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="stemmingResultaat">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Voor"/>
+            <xsd:enumeration value="Tegen"/>
+            <xsd:enumeration value="Gelijk"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="besluitvormingsstukkenType">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Hamerstukken"/>
+            <xsd:enumeration value="Bespreekstukken"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="vergaderingStatus">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Gepland"/>
+            <xsd:enumeration value="Gehouden"/>
+            <xsd:enumeration value="Geannuleerd"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="vergaderingstype">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Raadsvergadering"/>
+            <xsd:enumeration value="Commissievergadering"/>
+            <xsd:enumeration value="Statenvergadering"/>
+            <xsd:enumeration value="Algemene bestuursvergadering"/>
+            <xsd:enumeration value="Presidium"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="rolNaam">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Voorzitter"/>
+            <xsd:enumeration value="Vice-voorzitter"/>
+            <xsd:enumeration value="Raadslid"/>
+            <xsd:enumeration value="Statenlid"/>
+            <xsd:enumeration value="Dagelijks bestuurslid"/>
+            <xsd:enumeration value="Algemeen bestuurslid"/>
+            <xsd:enumeration value="Inspreker"/>
+            <xsd:enumeration value="Portefeuillehouder"/>
+            <xsd:enumeration value="Griffier"/>
+            <xsd:enumeration value="Overig"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="functie">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Burgemeester"/>
+            <xsd:enumeration value="Wethouder"/>
+            <xsd:enumeration value="Raadslid"/>
+            <xsd:enumeration value="Burgerlid"/>
+            <xsd:enumeration value="Griffier"/>
+            <xsd:enumeration value="Gemeentesecretaris"/>
+            <xsd:enumeration value="Commissaris van de Koning"/>
+            <xsd:enumeration value="Gedeputeerde"/>
+            <xsd:enumeration value="Statenlid"/>
+            <xsd:enumeration value="Provinciesecretaris"/>
+            <xsd:enumeration value="Dijkgraaf"/>
+            <xsd:enumeration value="Dagelijks bestuurslid"/>
+            <xsd:enumeration value="Algemeen bestuurslid"/>
+            <xsd:enumeration value="Secretarisdirecteur"/>
+            <xsd:enumeration value="Ambtenaar/medewerker"/>
+            <xsd:enumeration value="Adviseur of deskundige"/>
+            <xsd:enumeration value="Overig"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="geslacht">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Man"/>
+            <xsd:enumeration value="Vrouw"/>
+            <xsd:enumeration value="Anders"/>
+            <xsd:enumeration value="Onbekend"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="dagelijksBestuurstype">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="College"/>
+            <xsd:enumeration value="Gedeputeerde Staten"/>
+            <xsd:enumeration value="Dagelijks bestuur"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="provincie">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Drenthe"/>
+            <xsd:enumeration value="Groningen"/>
+            <xsd:enumeration value="Overijssel"/>
+            <xsd:enumeration value="Flevoland"/>
+            <xsd:enumeration value="Gelderland"/>
+            <xsd:enumeration value="Utrecht"/>
+            <xsd:enumeration value="Noord-Holland"/>
+            <xsd:enumeration value="Zuid-Holland"/>
+            <xsd:enumeration value="Zeeland"/>
+            <xsd:enumeration value="Noord-Brabant"/>
+            <xsd:enumeration value="Limburg"/>
+        </xsd:restriction>
+    </xsd:simpleType>
 </xsd:schema>

--- a/generate_docs/README.md
+++ b/generate_docs/README.md
@@ -1,0 +1,3 @@
+Script om op basis van de documentatie in [openapi.yaml](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie/blob/master/specificatie/openapi.yaml) de documentatie voor de XSD te genereren. Het script verwacht dat het bestand  `openapi.yaml` in dezelfde map staat.
+
+Werkt niet heel goed.

--- a/generate_docs/generate_docs.py
+++ b/generate_docs/generate_docs.py
@@ -1,0 +1,112 @@
+import yaml
+# needed because descriptions might contain html
+from markdownify import markdownify as md
+import xml.etree.ElementTree as ET
+import re
+
+f_xsd = "ORI.xsd"
+xsd_ns = 'https://www.w3.org/2001/XMLSchema'
+ns = {"xsd" : xsd_ns}
+# https://stackoverflow.com/questions/18338807/cannot-write-xml-file-with-default-namespace
+ET.register_namespace('xsd', xsd_ns)
+
+tree = ET.parse(f_xsd)
+xsd_root = tree.getroot()
+
+# read json
+with open("openapi.yaml") as yf:
+    yaml_data = yaml.safe_load(yf)
+
+element_names = [e.attrib['name'] for e in xsd_root.findall(".//xsd:element", ns)]
+
+def find_descriptions_for_element(target_element, yaml_data):
+    """recursively traverse dictionary, searching for an element's descriptions"""
+
+    descriptions = []
+    
+    if isinstance(yaml_data, dict):
+        for key, value in yaml_data.items():
+            # base case
+            if str(key).lower() == target_element.lower():
+                description = find_description(value)
+                if description:
+                    descriptions.append(description)
+            # traverse deeper
+            # extend is the same as append but works on iterables
+            descriptions.extend(find_descriptions_for_element(target_element, value))
+
+    elif isinstance(yaml_data, list):
+        # traverse list
+        for item in yaml_data:
+            descriptions.extend(find_descriptions_for_element(target_element, item))
+
+    return descriptions
+
+def find_description(yaml_data):
+    if isinstance(yaml_data, dict):
+        for key, value in yaml_data.items():
+            # base case
+            if key == 'description':
+                return value
+            else:
+                # go deeper
+                result = find_description(value)
+                if result:
+                    return result
+
+    elif isinstance(yaml_data, list):
+        for item in yaml_data:
+            result = find_description(item)
+            if result:
+                return result
+
+elem_descriptions = {}
+
+for e in element_names:
+    elem_descriptions[e] = find_descriptions_for_element(e, yaml_data)
+
+complexTypes = xsd_root.findall(".//xsd:complexType", ns)
+for ct in complexTypes:
+    ct_name = ct.attrib['name']
+    for e in ct.findall(".//xsd:element", ns):
+        e_name = e.attrib['name']
+        descriptions = list(set(elem_descriptions[e_name]))
+
+        if len(descriptions) == 0:
+            print(f"No description found for {ct_name}>{e_name}")
+            description = "TODO"
+        elif len(descriptions) > 1:
+            print(f"Descriptions for {ct_name}>{e_name}")
+            choices = [(i, d) for i, d in enumerate(descriptions)]
+            choices.append((len(choices), "TODO"))
+            descriptions.append("TODO")
+            print(choices)
+            # default answer is 0
+            try:
+                idx = int(input("Pick description [idx]: "))
+            except:
+                idx = 0 
+            description = descriptions[idx]
+        else:
+            description = descriptions[0]
+        
+        # capitalize and add period
+        if description != "TODO":
+            description = description[0].upper() + description[1:] + ('' if description.endswith('.') else '.')
+            description = description.replace('\n', ' ')
+            # replace ALLCAPS words
+            to_lowercase = lambda matchobj: "`" + matchobj.group(0).lower() + "`"
+            description = re.sub(r"\b[A-Z]+\b", to_lowercase, description)
+
+        # markdownify
+        description = md(description, escape_underscores=False, escape_asterisks=False)
+        annotation = ET.Element(f'{{{xsd_ns}}}annotation')
+        doc_xml = ET.Element(f'{{{xsd_ns}}}documentation')
+        doc_xml.text = description
+
+        annotation.append(doc_xml)
+        e.append(annotation)
+
+
+ET.indent(tree, space="	") # indent with tab
+tree.write('/tmp/ORI-doc.xsd', xml_declaration=True, encoding='utf-8')


### PR DESCRIPTION
Dit is wat ik op scripting basis kon genereren qua documentatie. Niet alle elementen zijn gedocumenteerd, en er zijn nog een hoop andere correcties nodig. Deze imperfecties komen deels door mijn script, maar ook door de formatting, spelling, en grammatica fouten in de originele bestanden. 

Van alle ALLCAPS strings in documentatie heb ik markdown code elementen gemaakt,voor zover dat kon. Ook heb ik de HTML in de documentatie omgezet naar markdown. Nog geen idee hoe dit rendered (en ik vind het er nu ook nog niet goed uitzien), maar in sommige talen zoals python is dit redelijk standaard.

Deze branch moet op dit moment niet gemerged worden, maar misschien wel interessant om via latere commits te tracken wat voor aanpassingen we aan de originele documentatie hebben gemaakt. Op deze manier kunnen we wellicht bijhouden hoe we ORI's originele documentatie kunnen verbeteren.

Fixt #8. 

## TODO

- [ ] Nu is veel van de documentatie een soort Van Dale - zou het niet meer sense maken als je in de documentatie vertelt hoe is iets gebruikt moet worden? iig zie ik niet in wat iemand leert van een definitie van het woord "vergadering"
   - goed voorbeeld van een stijl die mij meer aanspreekt: https://www.loc.gov/standards/mets/mets.xsd
- [ ] Vul `<xsd:documentation>TODO</xsd:documentation>` tags handmatig aan
- [ ] Fix spelling & grammatica
- [ ] Opmaak (punten, newlines, hoofdlettergeruik, bestaande markdown elementen)
  - [ ] Meer markdown/html toevoegen, waar het sense maakt (??)
    - Blijkbaar ondersteunen xml LSPs wel HTML rendering, maar kan markdown nog wel [wat](https://github.com/eclipse/lemminx/pull/988) werk [gebruiken](https://github.com/eclipse/lemminx/issues/962)   
- [ ] Gaan we in documentatie ook vertellen wat een gebruiker hoort in te vullen (bijvoorbeeld alle mogelijke opties uit een enumeratie)? MDTO doet dit niet, maar veel andere projecten wel.
  - In ieder geval moeten we hier consequenter in zijn dan nu het geval is 
- [ ] Hoe gaan we verwijzing documenteren, als die geïmplementeerd zijn?
- [ ] consequent zijn in woordgebruik

