### PR TITLE
Voeg de uitgang `Gegevens` toe aan alle complexTypes

### DIFF
--- a/ORI.xsd
+++ b/ORI.xsd
@@ -526,7 +526,7 @@
                 </xsd:simpleType>
             </xsd:element>
             <xsd:element name="naam" type="naamGegevens" minOccurs="1" maxOccurs="1"/>
-            <xsd:element name="nevenfunctieNatuurlijkPersoon" type="nevenfunctieGegevens" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="nevenfunctie" type="nevenfunctieGegevens" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="isLidVanFractie" type="fractielidmaatschapGegevens" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="isLidVanDagelijksBestuur" type="dagelijksBestuurLidmaatschapGegevens" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>

--- a/ORI.xsd
+++ b/ORI.xsd
@@ -531,7 +531,7 @@
             <xsd:element name="isLidVanDagelijksBestuur" type="dagelijksBestuurLidmaatschapGegevens" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>
     </xsd:complexType>
-    <xsd:complexType name="naamNatuurlijkPersoonGegevens">
+    <xsd:complexType name="naamGegevens">
         <xsd:sequence>
             <xsd:element name="achternaam" type="xsd:string" minOccurs="1" maxOccurs="1"/>
             <xsd:element name="tussenvoegsel" type="xsd:string" minOccurs="0" maxOccurs="1"/>
@@ -540,7 +540,7 @@
             <xsd:element name="volledigeNaam" type="xsd:string" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>
     </xsd:complexType>
-    <xsd:complexType name="nevenfunctieNatuurlijkPersoon">
+    <xsd:complexType name="nevenfunctieGegevens">
         <xsd:sequence>
             <xsd:element name="omschrijvingNevenfunctie" type="xsd:string" minOccurs="1" maxOccurs="1"/>
             <xsd:element name="naamOrganisatieNevenfunctie" type="xsd:string" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
De redenatie achter deze verandering is als volgt:

 * **Ambiguiteit verminderen.** In documentatie kan het mogelijk verwarring schelen als je element namen (bijv. `motie`) makkelijk kunt onderscheiden van complex types/gegevens die _onder_ een element moeten komen (bijv. `motieGegevens`).  Als alle complexTypes telkens dezelfde uitgang hebben - `...Gegevens`, in dit geval -  is het voor lezers meteen helder wat er bedoeld wordt.
 * Het voelt uberhaupt goed om dingen met andere rollen andere namen te geven.

Ik heb ook de naam van wat kindjes van `natuurlijkPersoon` veranderd. `nevenfunctieNatuurlijkPersoonGegevens` vond ik iets te lang, en kijkend naar het informatiemodel plaatje zou de naam van die tag sowieso  `nevenfunctie` ipv `nevenfunctieNatuurlijkPersoon` moeten zijn. 

Na deze verandering heb je wel twee subelementen met precies dezelfde naam (namelijk `naam` onder `natuurlijkPersoon` en `naam` onder `vergadering`), maar ik denk niet dat dat super veel verwarring gaat opleveren. 



Overigens is deze "naming convention" compleet van MDTO afgekeken. 

Sluit #38.